### PR TITLE
[Draft] Don't merge: Add vercel config/chinese search/disable graph view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ title: Configuration
 - [Documentation](https://obsidian-publisher.netlify.app/)
 - [Github Discussion](https://github.com/ObsidianPublisher/obsidian-github-publisher/discussions)
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FJackiexiao%2Fpublisher-template-vercel&project-name=obsidian-github-publish&repository-name=obsidian-github-publish)
+
+
 ## Mkdocs configuration
 
 You need to configure the plugin and the `mkdocs` configuration for it to work properly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
 share: true
 ---
-[TAGS]
+
+# home page

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,16 @@
 share: true
 ---
 
-# home page
+# home
+
+English: hello world
+Arabic: مرحبا بالعالم
+Chinese: 你好，世界
+Dutch: Hallo Wereld
+French: Bonjour le monde
+German: Hallo Welt
+Hindi: नमस्ते दुनिया
+Italian: Ciao mondo
+Japanese: こんにちは世界
+Russian: Привет, мир
+Spanish: Hola mundo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ extra_css:
 extra:
   SEO: assets/meta/SEO.png
   comments: false #disable comments globally
-  generate_graph: true #generate the graph of the site
+  generate_graph: false #generate the graph of the site
   attachments: 'assets/img' #path to the folder where the attachments are stored
   blog_list:
     pagination: true #enable pagination

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ mkdocs-meta-descriptions-plugin==2.2.0
 mkdocs-glightbox==0.3.2
 mkdocs-minify-plugin==0.6.4
 mkdocs-exclude==1.0.2
+jieba==0.42.1

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": null,
+  "installCommand": "pip install -r requirements.txt",
+  "buildCommand": "mkdocs build",
+  "outputDirectory": "site"
+}


### PR DESCRIPTION
vercel is easier to deploy for new beginner~ since it just need a click on button

- add vercel.json
- add `vercel deploy button` : https://vercel.com/docs/deploy-button
- disable graph view by default
-  add chinese search by add library: jieba according to  https://squidfunk.github.io/mkdocs-material/blog/2022/05/05/chinese-search-support/
- add `share: true` to prevent tags.md from delete


- depoly with vercel button still points to my repo
- known issue: mkdocs material have a pretty bad support for chinese character even we add `jieba` to requirements.txt, sometimes search won't work, refe to : https://github.com/squidfunk/mkdocs-material/issues/3915
